### PR TITLE
editor: Remove browse option from scene editor menu

### DIFF
--- a/src/gameeky/editor/scene.py
+++ b/src/gameeky/editor/scene.py
@@ -44,11 +44,9 @@ from ..common.widgets.about_window import present_about
 from ..common.widgets.documentation_wrapper import present_documentation
 from ..common.utils import (
     set_project_path,
-    get_project_path,
     get_project_folder,
     find_project_path,
     bytearray_to_string,
-    launch_path,
     launch_player,
 )
 
@@ -218,13 +216,6 @@ class Application(Adw.Application):
     def __on_about(self, action: Gio.SimpleAction, data: Optional[Any] = None) -> None:
         present_about(self._window)
 
-    def __on_browse(
-        self,
-        action: Gio.SimpleAction,
-        data: Optional[Any] = None,
-    ) -> None:
-        launch_path(get_project_path())
-
     def __on_documentation(
         self,
         action: Gio.SimpleAction,
@@ -306,10 +297,6 @@ class Application(Adw.Application):
         try_action = Gio.SimpleAction.new("try", None)
         try_action.connect("activate", self.__on_try)
         self.add_action(try_action)
-
-        browse_action = Gio.SimpleAction.new("browse", None)
-        browse_action.connect("activate", self.__on_browse)
-        self.add_action(browse_action)
 
         documentation_action = Gio.SimpleAction.new("documentation", None)
         documentation_action.connect("activate", self.__on_documentation)

--- a/src/gameeky/editor/widgets/scene_window.ui
+++ b/src/gameeky/editor/widgets/scene_window.ui
@@ -313,10 +313,6 @@
       <attribute name="label" translatable="yes">_Settings</attribute>
     </item>
     <item>
-      <attribute name="action">app.browse</attribute>
-      <attribute name="label" translatable="yes">_Browse Files</attribute>
-    </item>
-    <item>
       <attribute name="action">app.documentation</attribute>
       <attribute name="label" translatable="yes">_Documentation</attribute>
     </item>


### PR DESCRIPTION
There is no real need for this option to be there and this also helps with option pollution.