### PR TITLE
common: Properly quote arguments

### DIFF
--- a/src/gameeky/common/utils.py
+++ b/src/gameeky/common/utils.py
@@ -224,7 +224,7 @@ def quote(string: str) -> str:
     if not string:
         return string
     else:
-        return f"'{string}'"
+        return GLib.shell_quote(string)
 
 
 def find_new_name(directory: str, name: str) -> str:


### PR DESCRIPTION
This issue was spotted on a Windows host with the username being "ka'i", which clearly broke due to the hacky quoting approach.