### PR TITLE
Simplify screenshot captions in metainfo file

### DIFF
--- a/data/dev.tchx84.Gameeky.metainfo.xml.in
+++ b/data/dev.tchx84.Gameeky.metainfo.xml.in
@@ -23,23 +23,23 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <caption>Gameeky showing its scene editor</caption>
+      <caption>Scene editor</caption>
       <image>https://raw.githubusercontent.com/tchx84/Gameeky/main/data/screenshots/en/01.png</image>
     </screenshot>
     <screenshot>
-      <caption>Gameeky showing its game player</caption>
+      <caption>Game player</caption>
       <image>https://raw.githubusercontent.com/tchx84/Gameeky/main/data/screenshots/en/02.png</image>
     </screenshot>
     <screenshot>
-      <caption>Gameeky showing its entity editor</caption>
+      <caption>Entity editor</caption>
       <image>https://raw.githubusercontent.com/tchx84/Gameeky/main/data/screenshots/en/03.png</image>
     </screenshot>
     <screenshot>
-      <caption>Gameeky showing its game launcher</caption>
+      <caption>Game launcher</caption>
       <image>https://raw.githubusercontent.com/tchx84/Gameeky/main/data/screenshots/en/04.png</image>
     </screenshot>
     <screenshot>
-      <caption>Gameeky showing its code editor</caption>
+      <caption>Code editor</caption>
       <image>https://raw.githubusercontent.com/tchx84/Gameeky/main/data/screenshots/en/05.png</image>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
I believe having a smaller and more pragmatic caption for the screenshot might be better for the screen reader like Orca, instead of reading "Gameeky". I also saw other apps that had captions as simple my suggestions e.g. [Secrets](https://flathub.org/apps/org.gnome.World.Secrets).

P.s. This was done in the Accessibility Hackathon BoF by Pedro S Azevedo